### PR TITLE
Update layout.jade with "doctype html" instead of "doctype 5"

### DIFF
--- a/views/layout.jade
+++ b/views/layout.jade
@@ -1,4 +1,4 @@
-doctype 5
+doctype html
 html
   head
     title= title


### PR DESCRIPTION
This is the error message I got in terminal of lubuntu.
//
Error: /$HOME/docpad/node_modules/docpad-plugin-dce/views/layout.jade:1

> 1| doctype 5
>     2| html
>     3|   head
>     4|     title= title

`doctype 5` is deprecated, you must now use `doctype html`
//
